### PR TITLE
Fix for pathname in Windows and add astro version 5 peer dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,9 @@ export default function removeTagWhitespace() {
         };
 
         try {
-          await walkDir(dir.pathname);
+          let pathname = dir.pathname;
+          if (process.platform === 'win32') { pathname = pathname.replace('/', ''); }
+          await walkDir(pathname);
         } catch (error) {
           console.error('❌ Error in build hook:', error);
         }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
   },
   "homepage": "https://github.com/utsuboco/astro-remove-whitespace#readme",
   "peerDependencies": {
-    "astro": "^4.0.0"
+    "astro": "^4.0.0 || ^5.0.0"
   }
 }


### PR DESCRIPTION
Added a check for Windows, as it adds a '/' to dir.pathname and causes the integration to not work. Also added Astro ^5.0.0 to the peerDependencies